### PR TITLE
Issue26 sort lists

### DIFF
--- a/website.py
+++ b/website.py
@@ -59,10 +59,13 @@ def flukso(fluksoid):
     if f is None:
         abort(404)
 
+    sensors = f.get_sensors()
+    sensors.sort(key=lambda x: x.type)
+
     return render_template(
             'flukso.html',
             flukso=f,
-            sensors=f.get_sensors()
+            sensors=sensors
     )
 
 

--- a/website.py
+++ b/website.py
@@ -37,7 +37,9 @@ def index():
 
 @app.route("/data")
 def data():
-    return render_template('data.html', fluksos=hp.get_devices())
+    devices = hp.get_devices()
+    devices.sort(key=lambda x: x.key)
+    return render_template('data.html', fluksos=devices)
 
 
 @app.route("/development")


### PR DESCRIPTION
#26

The list of flukso devices gets sorted by key.
I also thought about sorting the sensor list on the flukso page, but by key (id) seems unnecessary, so what should it be? By description, or sensor type?
