### PR TITLE
Issue67 local houseprint config

### DIFF
--- a/website.py
+++ b/website.py
@@ -27,8 +27,13 @@ app.config.from_object(__name__)
 try:
     hp = houseprint.Houseprint()
 except:
-    print("Connection failed, loading houseprint from cache")
-    hp = houseprint.load_houseprint_from_file("cache_hp.hp")
+    try:
+        hp = houseprint.Houseprint(gjson=c.get('houseprint','json'))
+    except:
+        print("Connection failed, loading houseprint from cache")
+        hp = houseprint.load_houseprint_from_file("cache_hp.hp")
+    else:
+        hp.save("cache_hp.hp")
 else:
     hp.save("cache_hp.hp")
 


### PR DESCRIPTION
#67

So now the website tries 3 times to load the houseprint.
1. As default from the houseprint module (which uses the config file in the opengrid library)
2. Using the json path specified in opengrid.cfg (website version)
3. Using the cached version
