### PR TITLE
Revert "path to tmpo data"

### DIFF
--- a/website.py
+++ b/website.py
@@ -37,10 +37,7 @@ except:
 else:
     hp.save("cache_hp.hp")
 
-try:
-    hp.init_tmpo(path_to_tmpo_data=c.get('tmpo','data'))
-except:
-    hp.init_tmpo()
+hp.init_tmpo()
 
 
 @app.route("/")


### PR DESCRIPTION
Reverts opengridcc/website#72

@saroele when the houseprint tries to init tmpo on the path `/usr/local/data/.tmpo/`, I get `sqlite3.OperationalError: attempt to write a readonly database`. I suppose this has something to do with permissions?

I'm reverting because the site throws a 500.
